### PR TITLE
Changes to make it work for nette.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN unzip -q awscliv2.zip
 
 FROM vouchio/clj-jdk8-alpine:1.10.1
 
-RUN apk add --update --no-cache openssh git
+RUN apk add --update --no-cache openssh git jq curl
+RUN curl -s https://raw.githubusercontent.com/borkdude/jet/master/install -o install_jet && \
+    chmod +x ./install_jet && \
+    ./install_jet
 
 COPY --from=download-aws /aws /aws
 WORKDIR /aws

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN unzip -q awscliv2.zip
 
 FROM vouchio/clj-jdk8-alpine:1.10.1
 
-RUN apk add --update --no-cache openssh git curl
+RUN apk add --update --no-cache openssh git git-lfs curl
 RUN curl -s https://raw.githubusercontent.com/borkdude/jet/master/install -o install_jet && \
     chmod +x ./install_jet && \
     ./install_jet

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN unzip -q awscliv2.zip
 
 FROM vouchio/clj-jdk8-alpine:1.10.1
 
-RUN apk add --update --no-cache openssh git jq curl
+RUN apk add --update --no-cache openssh git curl
 RUN curl -s https://raw.githubusercontent.com/borkdude/jet/master/install -o install_jet && \
     chmod +x ./install_jet && \
     ./install_jet

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ When you need to fetch private gitlibs with tools.deps, use `ssh-key`
   uses: actions/datomic-ions-deploy@v0.1.0
   with:
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
-	app-name: ${{ env.APP_NAME }}
+    app-name: ${{ env.APP_NAME }}
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -192,7 +192,7 @@ When you need to fetch private gitlibs with tools.deps, use `ssh-key`
   with:
     alias: :dev
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
-	app-name: ${{ env.APP_NAME }}
+    app-name: ${{ env.APP_NAME }}
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -222,7 +222,7 @@ the ions code that is stored in another repository.
   uses: actions/datomic-ions-deploy@v0.1.0
   with:
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
-	app-name: ${{ env.APP_NAME }}
+    app-name: ${{ env.APP_NAME }}
     working-dir: my-ions-repo
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Note: Since the action is not interactive, it invokes the CLI via `clojure` rath
 
 **Required:** The compute group to which the ions should be deployed
 
+### `app-name`
+
+**Required**: The name of the datomic cloud stack.
+
 ### `ssh-key`
 
 **Optional:** A GitHub secret that has the The SSH key needed to access code from other private repositories (eg `${{ secrets.SSH_PRIVATE_KEY }}`)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ When you need to fetch private gitlibs with tools.deps, use `ssh-key`
   uses: actions/datomic-ions-deploy@v0.1.0
   with:
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
+	app-name: ${{ env.APP_NAME }}
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -191,6 +192,7 @@ When you need to fetch private gitlibs with tools.deps, use `ssh-key`
   with:
     alias: :dev
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
+	app-name: ${{ env.APP_NAME }}
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -220,6 +222,7 @@ the ions code that is stored in another repository.
   uses: actions/datomic-ions-deploy@v0.1.0
   with:
     compute-group: ${{ env.DATOMIC_COMPUTE_GROUP }}
+	app-name: ${{ env.APP_NAME }}
     working-dir: my-ions-repo
     aws-region: ${{ env.AWS_REGION }}
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: datomic-ions-deploy
-author: 'Stijn Opheide'
-description: 'Deploy Datomic ions to Datomic Cloud.'
+author: 'Pieter Breed'
+description: 'Deploy Datomic ions to Datomic Cloud. Forked from (https://github.com/vouch-opensource/datomic-ions-deploy) by Stijn Opheide'
 branding:
   icon: upload-cloud
-  color: blue
+  color: red
 inputs:
   alias:
     description: 'The alias that runs -m datomic.ion.dev'
@@ -28,6 +28,9 @@ inputs:
   ssh-key:
     description: 'GitHub secret with the SSH private key to access your private repositories'
     required: false
+  app-name:
+    description: "The datomic app name specified with the CloudFormation stack"
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -38,4 +41,5 @@ runs:
     - ${{ inputs.aws-access-key-id }}
     - ${{ inputs.aws-secret-access-key }}
     - ${{ inputs.working-directory }}
+    - ${{ inputs.app-name }}
     - ${{ inputs.ssh-key }}

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: datomic-ions-deploy
-author: 'Pieter Breed'
-description: 'Deploy Datomic ions to Datomic Cloud. Forked from (https://github.com/vouch-opensource/datomic-ions-deploy) by Stijn Opheide'
+author: 'Stijn Opheide'
+description: 'Deploy Datomic ions to Datomic Cloud.'
 branding:
   icon: upload-cloud
-  color: red
+  color: blue
 inputs:
   alias:
     description: 'The alias that runs -m datomic.ion.dev'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,8 @@ export AWS_REGION=$3
 export AWS_ACCESS_KEY_ID=$4
 export AWS_SECRET_ACCESS_KEY=$5
 WORKING_DIR=$6
-SSH_KEY=$7
+APP_NAME=$7
+SSH_KEY=$8
 
 ## Setup SSH Agent
 if [[ -n $SSH_KEY ]]
@@ -45,8 +46,8 @@ a_Opts="-A$aliases"
 function get_version {
   # Get the currently deployed version of the ions repo
   aws deploy get-deployment --deployment-id \
-    $(aws deploy list-deployments --application-name vouch --deployment-group-name $1 --include-only-statuses Succeeded --no-paginate --query "deployments[0]" --output text) \
-    --query "deploymentInfo.revision.s3Location.key" --output text | sed 's|^datomic/apps/vouch/stable/\(.*\).zip|\1|'
+    $(aws deploy list-deployments --application-name $2 --deployment-group-name $1 --include-only-statuses Succeeded --no-paginate --query "deployments[0]" --output text) \
+    --query "deploymentInfo.revision.s3Location.key" --output text | sed 's|^datomic/apps/.*/stable/\(.*\).zip|\1|'
 }
 
 function push {
@@ -100,7 +101,7 @@ function deploy {
   waitUntilDeployed "$1_$SHA"
 }
 
-if [[ $SHA != $(get_version $COMPUTE_GROUP) ]]; then
+if [[ $SHA != $(get_version $COMPUTE_GROUP $APP_NAME) ]]; then
   push
   deploy $COMPUTE_GROUP
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,7 +61,9 @@ function push {
 function getDeployStatus() {
   # Retrieve the status of the current deployment
   STATUS_COMMAND=$(jet -q ':status-command println' < .deploys/$1)
-  eval $STATUS_COMMAND | jet -q ':deploy-status println'
+  eval $STATUS_COMMAND > ".deploys/$1_status_output"
+  cat ".deploys/$1_status_output"
+  jet -q ':deploy-status println' < ".deploys/$1_status_output"
 }
 
 function waitUntilDeployed() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,10 +57,6 @@ function push {
 
 function getDeployStatus() {
   # Retrieve the status of the current deployment
-  # STATUS_COMMAND=$(clojure bin/parse-status-command.clj .deploys/$1)
-  # STATUS_EDN=$(eval $STATUS_COMMAND | tr -d '\n')
-  # clojure bin/parse-status.clj "$STATUS_EDN"
-
   STATUS_COMMAND=$(jet -q ':status-command' -o json < .deploys/$1 | jq -r)
   eval $STATUS_COMMAND | jet -q ':deploy-status' -o json | jq -r
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
 # print jet version
 jet -v

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 # Github Actions sets the home directory to /github/home which is not what the ions deploy tools expect
 # when using tools.deps gitlibs.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -x
 
 jet -v
 
@@ -62,7 +61,7 @@ function getDeployStatus() {
   # Retrieve the status of the current deployment
   STATUS_COMMAND=$(jet -q ':status-command println' < .deploys/$1)
   eval $STATUS_COMMAND > ".deploys/$1_status_output"
-  cat ".deploys/$1_status_output"
+  # cat ".deploys/$1_status_output"
   jet -q ':deploy-status println' < ".deploys/$1_status_output"
 }
 
@@ -96,7 +95,7 @@ function deploy {
 
   if [ $? -eq 0 ]; then
     echo $CLJ_OUTPUT >.deploys/$1_$SHA
-    cat .deploys/$1_$SHA
+    # cat .deploys/$1_$SHA
     set -e
   else
     echo $CLJ_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,9 +57,12 @@ function push {
 
 function getDeployStatus() {
   # Retrieve the status of the current deployment
-  STATUS_COMMAND=$(clojure bin/parse-status-command.clj .deploys/$1)
-  STATUS_EDN=$(eval $STATUS_COMMAND | tr -d '\n')
-  clojure bin/parse-status.clj "$STATUS_EDN"
+  # STATUS_COMMAND=$(clojure bin/parse-status-command.clj .deploys/$1)
+  # STATUS_EDN=$(eval $STATUS_COMMAND | tr -d '\n')
+  # clojure bin/parse-status.clj "$STATUS_EDN"
+
+  STATUS_COMMAND=$(jet -q ':status-command' -o json < .deploys/$1 | jq -r)
+  eval $STATUS_COMMAND | jet -q ':deploy-status' -o json | jq -r
 }
 
 function waitUntilDeployed() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,8 +57,8 @@ function push {
 
 function getDeployStatus() {
   # Retrieve the status of the current deployment
-  STATUS_COMMAND=$(jet -q ':status-command' -o json < .deploys/$1 | jq -r)
-  eval $STATUS_COMMAND | jet -q ':deploy-status' -o json | jq -r
+  STATUS_COMMAND=$(jet -q ':status-command println' < .deploys/$1)
+  eval $STATUS_COMMAND | jet -q ':deploy-status println'
 }
 
 function waitUntilDeployed() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
+# print jet version
 jet -v
 
 # Github Actions sets the home directory to /github/home which is not what the ions deploy tools expect
@@ -73,7 +75,7 @@ function waitUntilDeployed() {
 
   status=$(getDeployStatus $1)
 
-  while [[ ($status != "SUCCEEDED") && ($iterations -lt $max_iterations_count) ]]; do
+  while [[ ".$status" != ".SUCCEEDED" && ($iterations -lt $max_iterations_count) ]]; do
     sleep $sleep_time_seconds
     status=$(getDeployStatus $1)
     echo "Deploy $status"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+jet -v
+
 # Github Actions sets the home directory to /github/home which is not what the ions deploy tools expect
 # when using tools.deps gitlibs.
 # This is a work-around and might be removed when a solution is provided in ions deploy tools.
@@ -92,6 +94,7 @@ function deploy {
 
   if [ $? -eq 0 ]; then
     echo $CLJ_OUTPUT >.deploys/$1_$SHA
+    cat .deploys/$1_$SHA
     set -e
   else
     echo $CLJ_OUTPUT


### PR DESCRIPTION
I had to make one or two changes to this action to have it work for our setup:

- In `entrypoint.sh`, reference is made to `bin/parse-status-command.clj` and `bin/parse-status.clj`. Neither of these files are available in the docker image.
- I replaced the logic for `parse-status-command` and `parse-status` with [`jet`](https://github.com/borkdude/jet) and `jq`.
- I saw that `vouch` was hardcoded for the name of the datomic application name and replaced that with a parameter called `app-name`, which is mandatory.